### PR TITLE
adds React version in settings to clear lint warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,12 @@ module.exports = {
       jsx: true
     }
   },
+  "settings": {
+    "react": {
+      "pragma":"React",
+      "version": "16.4.2"
+    }
+  },
   rules: {
     indent: ["error", 2],
     "linebreak-style": ["error", "unix"],


### PR DESCRIPTION
I added a settings entry in .eslintrc with the React version and it appears to clear the warning when running lint. 